### PR TITLE
Fixed memory leaks

### DIFF
--- a/stripe.c
+++ b/stripe.c
@@ -476,6 +476,10 @@ int parse_pcap(FILE *capfile, FILE *outfile, fragment_list_t **fragtree, int mod
 	if(rechdr != NULL){
 		free(rechdr);
 	}
+
+    if (frame != NULL){
+        free(frame);
+    }
 	
 	if(fragmented == 1){
 		return(-1);
@@ -578,7 +582,7 @@ int main(int argc, char *argv[]){
 	
 	printf("\n%d frames processed.\n", packets);
 
-
+    free(parameters);
 	
 	return(0);
 }


### PR DESCRIPTION
This might fix bug #3 ; I couldn't reproduce the reported crashes, but valgrind found two issues which I think might be fixed by that patch. It simply adds two free()-statements.

Old valgrind results here: https://gist.github.com/yalla/72b740a73e13d15cef32
New valgrind results here: https://gist.github.com/yalla/bcc25378c076d06d9bdb

Resulting PCAP-files are binary-equal, for testing I used this GTP-U file from cloudshark: http://cloudshark.org/captures/374cf36574b6
