### PR TITLE
Allow run-time specification for tmp file location

### DIFF
--- a/stripe.h
+++ b/stripe.h
@@ -69,6 +69,7 @@ typedef struct pcaprec_hdr_s {
 typedef struct params_s {
 	char *infile;
 	char *outfile;
+	char *tmpfile;
 	char modifiers;
 } params_t;
 


### PR DESCRIPTION
This change adds a -t modifier that enables the caller to specify where
to store the temporary file. The temp file name will be reused, as there
does not appear to be any spot where multiple concurrent tempfiles are
needed. The argument is optional, and will default to "/tmp".